### PR TITLE
Nullability annotations

### DIFF
--- a/Core/NSError+Factory.h
+++ b/Core/NSError+Factory.h
@@ -2,7 +2,7 @@
 //  Created by Charles Parnot on 3/13/13.
 //  Licensed under the terms of the BSD License, as specified in the file 'LICENSE-BSD.txt' included with this distribution
 
-@import Cocoa;
+@import Foundation;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Core/NSError+Factory.h
+++ b/Core/NSError+Factory.h
@@ -2,6 +2,7 @@
 //  Created by Charles Parnot on 3/13/13.
 //  Licensed under the terms of the BSD License, as specified in the file 'LICENSE-BSD.txt' included with this distribution
 
+@import Cocoa;
 
 @interface NSError (Factory)
 + (NSError *)errorWithObject:(id)object code:(NSInteger)code localizedDescription:(NSString *)description underlyingError:(NSError *)underlyingError;

--- a/Core/NSError+Factory.h
+++ b/Core/NSError+Factory.h
@@ -4,6 +4,10 @@
 
 @import Cocoa;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSError (Factory)
-+ (NSError *)errorWithObject:(id)object code:(NSInteger)code localizedDescription:(NSString *)description underlyingError:(NSError *)underlyingError;
++ (NSError *)errorWithObject:(id)object code:(NSInteger)code localizedDescription:(nullable NSString *)description underlyingError:(nullable NSError *)underlyingError;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Core/PARDispatchQueue.h
+++ b/Core/PARDispatchQueue.h
@@ -38,6 +38,10 @@ typedef NS_ENUM(NSInteger, PARDeadlockBehavior)
 };
 
 
+// The APIs were audited. None of the method return values, method parameters or properties are nullable.
+NS_ASSUME_NONNULL_BEGIN
+
+
 @interface PARDispatchQueue : NSObject
 
 
@@ -87,5 +91,7 @@ typedef NS_ENUM(NSInteger, PARDeadlockBehavior)
 - (void)waitUntilFinished;
 @end
 
+
+NS_ASSUME_NONNULL_END
 
 #endif

--- a/Core/PARDispatchQueue.m
+++ b/Core/PARDispatchQueue.m
@@ -36,7 +36,7 @@ static int PARIsCurrentKey   = 1;
 + (PARDispatchQueue *)dispatchQueueWithLabel:(NSString *)label behavior:(PARDeadlockBehavior)behavior
 {
     PARDispatchQueue *newQueue = [self dispatchQueueWithGCDQueue:dispatch_queue_create([label UTF8String], DISPATCH_QUEUE_SERIAL) behavior:behavior];
-    newQueue._label = label;
+    newQueue._label = label ?: @"PARDispatchQueue";
     return newQueue;
 }
 

--- a/Core/PARNotificationSemaphore.h
+++ b/Core/PARNotificationSemaphore.h
@@ -4,6 +4,10 @@
 
 #import <Foundation/Foundation.h>
 
+
+// The APIs were audited. None of the method return values, method parameters or properties are nullable.
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PARNotificationSemaphore : NSObject
 
 + (PARNotificationSemaphore *)semaphoreForNotificationName:(NSString *)name object:(id)obj;
@@ -12,3 +16,5 @@
 @property (readonly) BOOL notificationWasPosted;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -28,16 +28,15 @@ extern NSString *PARStoreDidSyncNotification;
 @interface PARStore : NSObject <NSFilePresenter>
 
 /// @name Creating and Loading
-+ (instancetype)storeWithURL:(nullable NSURL *)url deviceIdentifier:(nullable NSString *)identifier;
++ (instancetype)storeWithURL:(nullable NSURL *)url deviceIdentifier:(NSString *)identifier;
 + (instancetype)inMemoryStore;
-- (instancetype)initWithURL:(nullable NSURL *)url deviceIdentifier:(nullable NSString *)identifier;
 - (void)load;
 - (void)closeDatabase;
 - (void)tearDown;
 
 /// @name Getting Store Information
 @property (readonly, copy, nullable) NSURL *storeURL;
-@property (readonly, copy, nullable) NSString *deviceIdentifier;
+@property (readonly, copy) NSString *deviceIdentifier;
 @property (readonly) BOOL loaded;
 @property (readonly) BOOL deleted;
 @property (readonly) BOOL inMemory;
@@ -51,10 +50,10 @@ extern NSString *PARStoreDidSyncNotification;
 - (void)runTransaction:(PARDispatchBlock)block;
 
 /// @name Adding and Accessing Blobs
-- (BOOL)writeBlobData:(nullable NSData *)data toPath:(nullable NSString *)path error:(NSError **)error;
-- (BOOL)writeBlobFromPath:(nullable NSString *)sourcePath toPath:(nullable NSString *)path error:(NSError **)error;
-- (nullable NSData *)blobDataAtPath:(nullable NSString *)path error:(NSError **)error;
-- (BOOL)deleteBlobAtPath:(nullable NSString *)path error:(NSError **)error;
+- (BOOL)writeBlobData:(NSData *)data toPath:(NSString *)path error:(NSError **)error;
+- (BOOL)writeBlobFromPath:(NSString *)sourcePath toPath:(NSString *)path error:(NSError **)error;
+- (nullable NSData *)blobDataAtPath:(NSString *)path error:(NSError **)error;
+- (BOOL)deleteBlobAtPath:(NSString *)path error:(NSError **)error;
 - (nullable NSString *)absolutePathForBlobPath:(NSString *)path;
 
 /// @name Syncing
@@ -75,10 +74,10 @@ extern NSString *PARStoreDidSyncNotification;
 + (NSNumber *)timestampForDistantPast;
 + (NSNumber *)timestampForDistantFuture;
 
-- (nullable NSDictionary *)mostRecentTimestampsByKey;
-- (nullable NSNumber *)mostRecentTimestampForKey:(nullable NSString *)key;
+- (NSDictionary *)mostRecentTimestampsByKey;
+- (nullable NSNumber *)mostRecentTimestampForKey:(NSString *)key;
 // These methods should not be called from within a transaction, or they will fail.
-- (nullable NSDictionary *)mostRecentTimestampsByDeviceIdentifier;
+- (NSDictionary *)mostRecentTimestampsByDeviceIdentifier;
 - (nullable NSNumber *)mostRecentTimestampForDeviceIdentifier:(nullable NSString *)deviceIdentifier;
 
 /// @name Synchronous Method Calls
@@ -93,7 +92,7 @@ extern NSString *PARStoreDidSyncNotification;
 
 /// @name History
 // This method returns an array of PARChange instances. It should not be called from within a transaction, or it will fail.
-- (nullable NSArray *)changesSinceTimestamp:(nullable NSNumber *)timestamp;
+- (NSArray *)changesSinceTimestamp:(nullable NSNumber *)timestamp;
 
 // TODO: error handling
 
@@ -101,13 +100,14 @@ extern NSString *PARStoreDidSyncNotification;
 
 
 @interface PARChange : NSObject
-+ (PARChange *)changeWithTimestamp:(nullable NSNumber *)timestamp parentTimestamp:(nullable NSNumber *)parentTimestamp key:(nullable NSString *)key propertyList:(nullable id)propertyList;
-@property (readonly, copy, nullable) NSNumber *timestamp;
++ (PARChange *)changeWithTimestamp:(NSNumber *)timestamp parentTimestamp:(nullable NSNumber *)parentTimestamp key:(NSString *)key propertyList:(id)propertyList;
+@property (readonly, copy) NSNumber *timestamp;
 @property (readonly, copy, nullable) NSNumber *parentTimestamp;
-@property (readonly, copy, nullable) NSString *key;
-@property (readonly, copy, nullable) id propertyList;
+@property (readonly, copy) NSString *key;
+@property (readonly, copy) id propertyList;
 - (BOOL)isEqual:(nullable id)object;
 @end
+
 
 NS_ASSUME_NONNULL_END
 

--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -13,9 +13,10 @@
 /// Note on memory management: before releasing a store object, it is recommended to call `saveNow` or `waitUntilFinished`, but not necessary. Any change will schedule a save operation that will still be performed and the object will still be retained until that happens. It is not necessary to explicitely `close` a store.
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// @name Notifications
 /// Notifications are posted asynchronously. You cannot expect the store to be in the state that it was after the last operation that triggered the notification. The 'Change' and 'Sync' notifications includes a user info dictionary with two entries @"values" and @"timestamps"; each entry contain a dictionary where the keys correspond to the keys changed by the sync, and the values corresponding property list values and timestamps, respectively. In the case of 'Sync' notifications, these are the same dictionaries as the one passed to the method `applySyncChangeWithValues:timestamps:`.
-NS_ASSUME_NONNULL_BEGIN
 extern NSString *PARStoreDidLoadNotification;
 extern NSString *PARStoreDidTearDownNotification;
 extern NSString *PARStoreDidDeleteNotification;
@@ -31,7 +32,6 @@ extern NSString *PARStoreDidSyncNotification;
 - (void)load;
 - (void)closeDatabase;
 - (void)tearDown;
-NS_ASSUME_NONNULL_END
 
 /// @name Getting Store Information
 @property (readonly, copy, nullable) NSURL *storeURL;
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_END
 @property (readonly) BOOL inMemory;
 
 /// @name Adding and Accessing Values
-- (id)propertyListValueForKey:(NSString *)key;
+- (nullable id)propertyListValueForKey:(NSString *)key;
 - (void)setPropertyListValue:(id)plist forKey:(NSString *)key;
 - (NSArray *)allUniqueKeys;
 - (NSDictionary *)allRelevantValues;
@@ -49,26 +49,26 @@ NS_ASSUME_NONNULL_END
 - (void)runTransaction:(PARDispatchBlock)block;
 
 /// @name Adding and Accessing Blobs
-- (BOOL)writeBlobData:(NSData *)data toPath:(NSString *)path error:(NSError **)error;
-- (BOOL)writeBlobFromPath:(NSString *)sourcePath toPath:(NSString *)path error:(NSError **)error;
-- (NSData *)blobDataAtPath:(NSString *)path error:(NSError **)error;
-- (BOOL)deleteBlobAtPath:(NSString *)path error:(NSError **)error;
-- (NSString *)absolutePathForBlobPath:(NSString *)path;
+- (BOOL)writeBlobData:(nullable NSData *)data toPath:(nullable NSString *)path error:(NSError **)error;
+- (BOOL)writeBlobFromPath:(nullable NSString *)sourcePath toPath:(nullable NSString *)path error:(NSError **)error;
+- (nullable NSData *)blobDataAtPath:(nullable NSString *)path error:(NSError **)error;
+- (BOOL)deleteBlobAtPath:(nullable NSString *)path error:(NSError **)error;
+- (nullable NSString *)absolutePathForBlobPath:(NSString *)path;
 
 /// @name Syncing
 - (void)sync;
+
 // These methods should not be called from within a transaction, or they will fail.
-- (id)syncedPropertyListValueForKey:(NSString *)key;
-- (id)syncedPropertyListValueForKey:(NSString *)key timestamp:(NSNumber *)timestamp;
+- (nullable id)syncedPropertyListValueForKey:(NSString *)key;
+- (nullable id)syncedPropertyListValueForKey:(NSString *)key timestamp:(nullable NSNumber *)timestamp;
 // for subclassing
 - (NSArray *)relevantKeysForSync;
-- (void)applySyncChangeWithValues:(NSDictionary *)values timestamps:(NSDictionary *)timestamps;
+- (void)applySyncChangeWithValues:(NSDictionary *)values timestamps:(NSDictionary *)timestamps NS_REQUIRES_SUPER;
 
 /// @name Merging
-- (void)mergeStore:(PARStore *)store unsafeDeviceIdentifiers:(NSArray *)activeDeviceIdentifiers completionHandler:(void(^)(NSError*))completionHandler;
+- (void)mergeStore:(PARStore *)store unsafeDeviceIdentifiers:(NSArray *)activeDeviceIdentifiers completionHandler:(nullable void(^)(NSError*))completionHandler;
 
 /// @name Getting Timestamps
-NS_ASSUME_NONNULL_BEGIN
 + (NSNumber *)timestampNow;
 + (NSNumber *)timestampForDistantPast;
 + (NSNumber *)timestampForDistantFuture;
@@ -94,20 +94,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSArray *)changesSinceTimestamp:(nullable NSNumber *)timestamp;
 
 // TODO: error handling
-NS_ASSUME_NONNULL_END
 
 @end
 
 
 @interface PARChange : NSObject
-+ (PARChange *)changeWithTimestamp:(NSNumber *)timestamp parentTimestamp:(NSNumber *)parentTimestamp key:(NSString *)key propertyList:(id)propertyList;
-@property (readonly, copy) NSNumber *timestamp;
-@property (readonly, copy) NSNumber *parentTimestamp;
-@property (readonly, copy) NSString *key;
-@property (readonly, copy) id propertyList;
-- (BOOL)isEqual:(id)object;
++ (PARChange *)changeWithTimestamp:(nullable NSNumber *)timestamp parentTimestamp:(nullable NSNumber *)parentTimestamp key:(nullable NSString *)key propertyList:(nullable id)propertyList;
+@property (readonly, copy, nullable) NSNumber *timestamp;
+@property (readonly, copy, nullable) NSNumber *parentTimestamp;
+@property (readonly, copy, nullable) NSString *key;
+@property (readonly, copy, nullable) id propertyList;
+- (BOOL)isEqual:(nullable id)object;
 @end
 
+NS_ASSUME_NONNULL_END
 
 /** Subclassing notes:
 

--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -43,6 +43,7 @@ NS_ASSUME_NONNULL_END
 /// @name Adding and Accessing Values
 - (id)propertyListValueForKey:(NSString *)key;
 - (void)setPropertyListValue:(id)plist forKey:(NSString *)key;
+- (NSArray *)allUniqueKeys;
 - (NSDictionary *)allRelevantValues;
 - (void)setEntriesFromDictionary:(NSDictionary *)dictionary;
 - (void)runTransaction:(PARDispatchBlock)block;

--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -4,6 +4,7 @@
 
 #import "PARDispatchQueue.h"
 
+
 /// Key-value store for local storage of app data, with the following characteristics:
 ///  - persistent storage in a file package
 ///  - transparent syncing between multiple devices sharing the file via Dropbox, iCloud, or other file-based syncing system
@@ -14,12 +15,13 @@
 
 /// @name Notifications
 /// Notifications are posted asynchronously. You cannot expect the store to be in the state that it was after the last operation that triggered the notification. The 'Change' and 'Sync' notifications includes a user info dictionary with two entries @"values" and @"timestamps"; each entry contain a dictionary where the keys correspond to the keys changed by the sync, and the values corresponding property list values and timestamps, respectively. In the case of 'Sync' notifications, these are the same dictionaries as the one passed to the method `applySyncChangeWithValues:timestamps:`.
+NS_ASSUME_NONNULL_BEGIN
 extern NSString *PARStoreDidLoadNotification;
 extern NSString *PARStoreDidTearDownNotification;
 extern NSString *PARStoreDidDeleteNotification;
 extern NSString *PARStoreDidChangeNotification;
 extern NSString *PARStoreDidSyncNotification;
-
+NS_ASSUME_NONNULL_END
 
 @interface PARStore : NSObject <NSFilePresenter>
 

--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -64,14 +64,16 @@ extern NSString *PARStoreDidSyncNotification;
 - (void)mergeStore:(PARStore *)store unsafeDeviceIdentifiers:(NSArray *)activeDeviceIdentifiers completionHandler:(void(^)(NSError*))completionHandler;
 
 /// @name Getting Timestamps
+NS_ASSUME_NONNULL_BEGIN
 + (NSNumber *)timestampNow;
 + (NSNumber *)timestampForDistantPast;
 + (NSNumber *)timestampForDistantFuture;
-- (NSDictionary *)mostRecentTimestampsByKey;
-- (NSNumber *)mostRecentTimestampForKey:(NSString *)key;
+
+- (nullable NSDictionary *)mostRecentTimestampsByKey;
+- (nullable NSNumber *)mostRecentTimestampForKey:(nullable NSString *)key;
 // These methods should not be called from within a transaction, or they will fail.
 - (NSDictionary *)mostRecentTimestampsByDeviceIdentifier;
-- (NSNumber *)mostRecentTimestampForDeviceIdentifier:(NSString *)deviceIdentifier;
+- (nullable NSNumber *)mostRecentTimestampForDeviceIdentifier:(nullable NSString *)deviceIdentifier;
 
 /// @name Synchronous Method Calls
 // Synchronous calls can potentially result in longer wait, and should be avoided in the main thread. These should not be called from within a transaction, or they will fail.
@@ -85,9 +87,10 @@ extern NSString *PARStoreDidSyncNotification;
 
 /// @name History
 // This method returns an array of PARChange instances. It should not be called from within a transaction, or it will fail.
-- (NSArray *)changesSinceTimestamp:(NSNumber *)timestamp;
+- (NSArray *)changesSinceTimestamp:(nullable NSNumber *)timestamp;
 
 // TODO: error handling
+NS_ASSUME_NONNULL_END
 
 @end
 

--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSDictionary *)mostRecentTimestampsByKey;
 - (nullable NSNumber *)mostRecentTimestampForKey:(nullable NSString *)key;
 // These methods should not be called from within a transaction, or they will fail.
-- (NSDictionary *)mostRecentTimestampsByDeviceIdentifier;
+- (nullable NSDictionary *)mostRecentTimestampsByDeviceIdentifier;
 - (nullable NSNumber *)mostRecentTimestampForDeviceIdentifier:(nullable NSString *)deviceIdentifier;
 
 /// @name Synchronous Method Calls

--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -75,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSDictionary *)mostRecentTimestampsByKey;
 - (nullable NSNumber *)mostRecentTimestampForKey:(nullable NSString *)key;
 // These methods should not be called from within a transaction, or they will fail.
-- (NSDictionary *)mostRecentTimestampsByDeviceIdentifier;
+- (nullable NSDictionary *)mostRecentTimestampsByDeviceIdentifier;
 - (nullable NSNumber *)mostRecentTimestampForDeviceIdentifier:(nullable NSString *)deviceIdentifier;
 
 /// @name Synchronous Method Calls
@@ -90,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// @name History
 // This method returns an array of PARChange instances. It should not be called from within a transaction, or it will fail.
-- (NSArray *)changesSinceTimestamp:(nullable NSNumber *)timestamp;
+- (nullable NSArray *)changesSinceTimestamp:(nullable NSNumber *)timestamp;
 
 // TODO: error handling
 NS_ASSUME_NONNULL_END

--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -15,6 +15,9 @@
 
 /// @name Notifications
 /// Notifications are posted asynchronously. You cannot expect the store to be in the state that it was after the last operation that triggered the notification. The 'Change' and 'Sync' notifications includes a user info dictionary with two entries @"values" and @"timestamps"; each entry contain a dictionary where the keys correspond to the keys changed by the sync, and the values corresponding property list values and timestamps, respectively. In the case of 'Sync' notifications, these are the same dictionaries as the one passed to the method `applySyncChangeWithValues:timestamps:`.
+
+// TODO: add documentation to methods, also include whether the method will hit the db or not
+
 NS_ASSUME_NONNULL_BEGIN
 extern NSString *PARStoreDidLoadNotification;
 extern NSString *PARStoreDidTearDownNotification;
@@ -62,7 +65,7 @@ NS_ASSUME_NONNULL_END
 - (id)syncedPropertyListValueForKey:(NSString *)key timestamp:(NSNumber *)timestamp;
 // for subclassing
 - (NSArray *)relevantKeysForSync;
-- (void)applySyncChangeWithValues:(NSDictionary *)values timestamps:(NSDictionary *)timestamps;
+- (void)applySyncChangeWithValues:(NSDictionary *)values timestamps:(NSDictionary *)timestamps; 
 
 /// @name Merging
 - (void)mergeStore:(PARStore *)store unsafeDeviceIdentifiers:(NSArray *)activeDeviceIdentifiers completionHandler:(void(^)(NSError*))completionHandler;

--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -21,20 +21,21 @@ extern NSString *PARStoreDidTearDownNotification;
 extern NSString *PARStoreDidDeleteNotification;
 extern NSString *PARStoreDidChangeNotification;
 extern NSString *PARStoreDidSyncNotification;
-NS_ASSUME_NONNULL_END
 
 @interface PARStore : NSObject <NSFilePresenter>
 
 /// @name Creating and Loading
-+ (id)storeWithURL:(NSURL *)url deviceIdentifier:(NSString *)identifier;
++ (id)storeWithURL:(nullable NSURL *)url deviceIdentifier:(nullable NSString *)identifier;
 + (id)inMemoryStore;
+- (instancetype)initWithURL:(nullable NSURL *)url deviceIdentifier:(nullable NSString *)identifier;
 - (void)load;
 - (void)closeDatabase;
 - (void)tearDown;
+NS_ASSUME_NONNULL_END
 
 /// @name Getting Store Information
-@property (readonly, copy) NSURL *storeURL;
-@property (readonly, copy) NSString *deviceIdentifier;
+@property (readonly, copy, nullable) NSURL *storeURL;
+@property (readonly, copy, nullable) NSString *deviceIdentifier;
 @property (readonly) BOOL loaded;
 @property (readonly) BOOL deleted;
 @property (readonly) BOOL inMemory;

--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -25,8 +25,8 @@ extern NSString *PARStoreDidSyncNotification;
 @interface PARStore : NSObject <NSFilePresenter>
 
 /// @name Creating and Loading
-+ (id)storeWithURL:(nullable NSURL *)url deviceIdentifier:(nullable NSString *)identifier;
-+ (id)inMemoryStore;
++ (instancetype)storeWithURL:(nullable NSURL *)url deviceIdentifier:(nullable NSString *)identifier;
++ (instancetype)inMemoryStore;
 - (instancetype)initWithURL:(nullable NSURL *)url deviceIdentifier:(nullable NSString *)identifier;
 - (void)load;
 - (void)closeDatabase;

--- a/Core/PARStore.m
+++ b/Core/PARStore.m
@@ -84,12 +84,13 @@ NSString *const ParentTimestampAttributeName = @"parentTimestamp";
 
 + (instancetype)storeWithURL:(NSURL *)url deviceIdentifier:(NSString *)identifier
 {
-    return [[self alloc] initWithURL:url deviceIdentifier: identifier];
+    return [[self alloc] initWithURL:url deviceIdentifier:identifier];
 }
 
 - (instancetype)initWithURL:(NSURL *)url deviceIdentifier:(NSString *)identifier
 {
-    if (self = [super init]) {
+    if (self = [super init])
+    {
         self.storeURL = url;
         self.deviceIdentifier = identifier;
         
@@ -127,7 +128,7 @@ NSString *const ParentTimestampAttributeName = @"parentTimestamp";
 
 + (instancetype)inMemoryStore
 {
-    return [self storeWithURL:nil deviceIdentifier:nil];
+    return [self storeWithURL:nil deviceIdentifier:@""];
 }
 
 - (NSString *)description
@@ -2103,7 +2104,9 @@ NSString *PARDevicesDirectoryName = @"devices";
 - (NSNumber *)mostRecentTimestampForDeviceIdentifier:(NSString *)deviceIdentifier
 {
     if (deviceIdentifier == nil)
+    {
         return nil;
+    }
 
     if ([self.memoryQueue isInCurrentQueueStack])
     {
@@ -2133,7 +2136,9 @@ NSString *PARDevicesDirectoryName = @"devices";
 - (NSNumber *)mostRecentTimestampForKey:(NSString *)key
 {
     if (key == nil)
+    {
         return nil;
+    }
     __block NSNumber *timestamp = nil;
     [self.memoryQueue dispatchSynchronously:^ { timestamp = self._memoryKeyTimestamps[key]; }];
     return timestamp;
@@ -2191,8 +2196,11 @@ NSString *PARDevicesDirectoryName = @"devices";
             NSString *key = logDictionary[KeyAttributeName];
             NSData *blob = logDictionary[BlobAttributeName];
             id propertyList = [self propertyListFromData:blob error:NULL];
-            PARChange *change = [PARChange changeWithTimestamp:timestamp parentTimestamp:parentTimestamp key:key propertyList:propertyList];
-            [changes addObject:change];
+            if (timestamp != nil && key != nil && blob != nil)
+            {
+                PARChange *change = [PARChange changeWithTimestamp:timestamp parentTimestamp:parentTimestamp key:key propertyList:propertyList];
+                [changes addObject:change];
+            }
         }
         
         [self closeDatabaseSoon];

--- a/Core/PARStore.m
+++ b/Core/PARStore.m
@@ -84,31 +84,36 @@ NSString *const ParentTimestampAttributeName = @"parentTimestamp";
 
 + (id)storeWithURL:(NSURL *)url deviceIdentifier:(NSString *)identifier
 {
-    PARStore *store = [[self alloc] init];
-    store.storeURL = url;
-    store.deviceIdentifier = identifier;
-    
-    // queue labels appear in crash reports and other debugging info
-    NSString *urlLabel = [[url lastPathComponent] stringByReplacingOccurrencesOfString:@"." withString:@"_"];
-    NSString *databaseQueueLabel = [PARDispatchQueue labelByPrependingBundleIdentifierToString:[NSString stringWithFormat:@"database.%@", urlLabel]];
-    NSString *memoryQueueLabel = [PARDispatchQueue labelByPrependingBundleIdentifierToString:[NSString stringWithFormat:@"memory.%@", urlLabel]];
-    NSString *notificationQueueLabel = [PARDispatchQueue labelByPrependingBundleIdentifierToString:[NSString stringWithFormat:@"notifications.%@", urlLabel]];
-    store.databaseQueue     = [PARDispatchQueue dispatchQueueWithLabel:databaseQueueLabel];
-    store.memoryQueue       = [PARDispatchQueue dispatchQueueWithLabel:memoryQueueLabel];
-    store.notificationQueue = [PARDispatchQueue dispatchQueueWithLabel:notificationQueueLabel];
-    [store createFileSystemEventQueue];
-    
-    // misc initializations
-    store.databaseTimestamps = [NSMutableDictionary dictionary];
-    store.presenterQueue = [[NSOperationQueue alloc] init];
-    [store.presenterQueue setMaxConcurrentOperationCount:1];
-    store._memory = [NSMutableDictionary dictionary];
-    store._memoryFileData = [NSMutableDictionary dictionary];
-    store._memoryKeyTimestamps = [NSMutableDictionary dictionary];
-    store._loaded = NO;
-    store._deleted = NO;
-	
-    return store;
+    return [[self alloc] initWithURL:url deviceIdentifier: identifier];
+}
+
+- (instancetype)initWithURL:(NSURL *)url deviceIdentifier:(NSString *)identifier
+{
+    if (self = [super init]) {
+        self.storeURL = url;
+        self.deviceIdentifier = identifier;
+        
+        // queue labels appear in crash reports and other debugging info
+        NSString *urlLabel = [[url lastPathComponent] stringByReplacingOccurrencesOfString:@"." withString:@"_"];
+        NSString *databaseQueueLabel = [PARDispatchQueue labelByPrependingBundleIdentifierToString:[NSString stringWithFormat:@"database.%@", urlLabel]];
+        NSString *memoryQueueLabel = [PARDispatchQueue labelByPrependingBundleIdentifierToString:[NSString stringWithFormat:@"memory.%@", urlLabel]];
+        NSString *notificationQueueLabel = [PARDispatchQueue labelByPrependingBundleIdentifierToString:[NSString stringWithFormat:@"notifications.%@", urlLabel]];
+        self.databaseQueue     = [PARDispatchQueue dispatchQueueWithLabel:databaseQueueLabel];
+        self.memoryQueue       = [PARDispatchQueue dispatchQueueWithLabel:memoryQueueLabel];
+        self.notificationQueue = [PARDispatchQueue dispatchQueueWithLabel:notificationQueueLabel];
+        [self createFileSystemEventQueue];
+        
+        // misc initializations
+        self.databaseTimestamps = [NSMutableDictionary dictionary];
+        self.presenterQueue = [[NSOperationQueue alloc] init];
+        [self.presenterQueue setMaxConcurrentOperationCount:1];
+        self._memory = [NSMutableDictionary dictionary];
+        self._memoryFileData = [NSMutableDictionary dictionary];
+        self._memoryKeyTimestamps = [NSMutableDictionary dictionary];
+        self._loaded = NO;
+        self._deleted = NO;
+    }
+    return self;
 }
 
 + (id)inMemoryStore

--- a/Core/PARStore.m
+++ b/Core/PARStore.m
@@ -1055,6 +1055,7 @@ NSString *PARDevicesDirectoryName = @"devices";
     return YES;
 }
 
+// TODO: rename to copyBlobFromPath:toPath:error:, the current name is ambiguous
 - (BOOL)writeBlobFromPath:(NSString *)sourcePath toPath:(NSString *)targetSubpath error:(NSError **)error
 {
     // nil local path = error
@@ -1290,6 +1291,8 @@ NSString *PARDevicesDirectoryName = @"devices";
     {
         // there are 2 ways to determine `timestampLimit`, which depends on wether a new database was added since the last sync
         [self refreshStoreList];
+        
+        // we can count databases because the count would always go up (db's are not deleted)
         NSUInteger countAllDatabasesBefore   = [self.databaseTimestamps count];
         NSUInteger countReadonlyDatabasesNow = [self.readonlyDatabases count];
         NSAssert(countReadonlyDatabasesNow + 1 >= countAllDatabasesBefore, @"Inconsistent tracking of persistent stores");
@@ -1305,7 +1308,7 @@ NSString *PARDevicesDirectoryName = @"devices";
         }
     }
     
-    // fetch Log rows in reverse timestamp order, starting at `timestampLimit`
+    // fetch Log rows created after the `timestampLimit` in reverse timestamp order (newest first) 
     NSError *errorLogs = nil;
     NSFetchRequest *logsRequest = [NSFetchRequest fetchRequestWithEntityName:LogEntityName];
     if (timestampLimit)
@@ -1504,7 +1507,7 @@ NSString *PARDevicesDirectoryName = @"devices";
              plist = [self propertyListFromData:[latestLog valueForKey:BlobAttributeName] error:&plistError];
              if (plist == nil)
              {
-                 ErrorLog(@"Error deserializing 'layout' data in Logs database:\nrow: %@\nfile: %@\nerror: %@", latestLog.objectID, latestLog.objectID.persistentStore.URL.path, plistError);
+                 ErrorLog(@"Error deserializing 'blob' data in Logs database:\nrow: %@\nfile: %@\nerror: %@", latestLog.objectID, latestLog.objectID.persistentStore.URL.path, plistError);
              }
          }
          
@@ -2136,6 +2139,10 @@ NSString *PARDevicesDirectoryName = @"devices";
 
 
 #pragma mark - History
+
+// TODO: in swift port add:
+// changes(since timestamp: Timestamp?, forKey key: String? = nil, from device: Device? = nil) -> [Change] where a nil timestamp means distantpast and a nil key means all keys, and a nil device means all devices
+// changes(forKey key: String? = nil, from device: Device? = nil) -> [Change]  that calls changes(since:nil, forKey: key, from:nil), and where changes() gives you all changes
 
 - (NSArray *)changesSinceTimestamp:(NSNumber *)timestampLimit
 {

--- a/Core/PARStore.m
+++ b/Core/PARStore.m
@@ -84,7 +84,7 @@ NSString *const ParentTimestampAttributeName = @"parentTimestamp";
 
 + (id)storeWithURL:(NSURL *)url deviceIdentifier:(NSString *)identifier
 {
-    return [[self alloc] initWithURL:url deviceIdentifier: identifier];
+    return [[PARStore alloc] initWithURL:url deviceIdentifier: identifier];
 }
 
 - (instancetype)initWithURL:(NSURL *)url deviceIdentifier:(NSString *)identifier
@@ -112,20 +112,22 @@ NSString *const ParentTimestampAttributeName = @"parentTimestamp";
         self._memoryKeyTimestamps = [NSMutableDictionary dictionary];
         self._loaded = NO;
         self._deleted = NO;
+        
+        // in memory store?
+        if (url == nil)
+        {
+            self._inMemory = YES;
+            self._loaded = YES;
+            // no database layer, already loaded
+            self.databaseQueue = nil;
+        }
     }
     return self;
 }
 
-+ (id)inMemoryStore
++ (instancetype)inMemoryStore
 {
-    PARStore *store = [self storeWithURL:nil deviceIdentifier:nil];
-    store._inMemory = YES;
-    
-    // no database layer, already loaded
-    store.databaseQueue = nil;
-    store._loaded = YES;
-    
-    return store;
+    return [self storeWithURL:nil deviceIdentifier:nil];
 }
 
 - (NSString *)description

--- a/PARStore.xcodeproj/project.pbxproj
+++ b/PARStore.xcodeproj/project.pbxproj
@@ -320,7 +320,6 @@
 				56C7EDDC16E260EB00FFBBF2 /* Sources */,
 				56C7EDDD16E260EB00FFBBF2 /* Frameworks */,
 				56C7EDDE16E260EB00FFBBF2 /* Resources */,
-				56C7EDDF16E260EB00FFBBF2 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -356,7 +355,6 @@
 				56EAE18216E24C7500A7F31F /* Sources */,
 				56EAE18316E24C7500A7F31F /* Frameworks */,
 				56EAE18416E24C7500A7F31F /* Resources */,
-				56EAE18516E24C7500A7F31F /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -437,35 +435,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		56C7EDDF16E260EB00FFBBF2 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
-		};
-		56EAE18516E24C7500A7F31F /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		56C7EDBE16E260EA00FFBBF2 /* Sources */ = {

--- a/PARStore.xcodeproj/project.pbxproj
+++ b/PARStore.xcodeproj/project.pbxproj
@@ -699,6 +699,7 @@
 		56EAE19916E24C7500A7F31F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Mac/PARStore-Prefix.pch";
@@ -712,6 +713,7 @@
 		56EAE19A16E24C7500A7F31F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Mac/PARStore-Prefix.pch";


### PR DESCRIPTION
- Nullability annotations for swift compatibility
- PARStore subclasses that don't override `relevantKeysForSync` will now simply load all the existing keys from the logs on disk. This behavior will soon be the only behavior, but further adjustments are still needed.
