### PR TITLE
Always fetching all keys when loading or syncing a store

### DIFF
--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -44,8 +44,8 @@ extern NSString *PARStoreDidSyncNotification;
 /// @name Adding and Accessing Values
 - (nullable id)propertyListValueForKey:(NSString *)key;
 - (void)setPropertyListValue:(id)plist forKey:(NSString *)key;
-- (NSArray *)allUniqueKeys;
-- (NSDictionary *)allRelevantValues;
+- (NSArray *)allKeys;
+- (NSDictionary *)allEntries;
 - (void)setEntriesFromDictionary:(NSDictionary *)dictionary;
 - (void)runTransaction:(PARDispatchBlock)block;
 
@@ -60,10 +60,10 @@ extern NSString *PARStoreDidSyncNotification;
 - (void)sync;
 
 // These methods should not be called from within a transaction, or they will fail.
-- (nullable id)syncedPropertyListValueForKey:(NSString *)key;
-- (nullable id)syncedPropertyListValueForKey:(NSString *)key timestamp:(nullable NSNumber *)timestamp;
+- (NSArray *)fetchAllKeys;
+- (nullable id)fetchPropertyListValueForKey:(NSString *)key;
+- (nullable id)fetchPropertyListValueForKey:(NSString *)key timestamp:(nullable NSNumber *)timestamp;
 // for subclassing
-- (NSArray *)relevantKeysForSync;
 - (void)applySyncChangeWithValues:(NSDictionary *)values timestamps:(NSDictionary *)timestamps NS_REQUIRES_SUPER;
 
 /// @name Merging
@@ -92,7 +92,7 @@ extern NSString *PARStoreDidSyncNotification;
 
 /// @name History
 // This method returns an array of PARChange instances. It should not be called from within a transaction, or it will fail.
-- (NSArray *)changesSinceTimestamp:(nullable NSNumber *)timestamp;
+- (NSArray *)fetchChangesSinceTimestamp:(nullable NSNumber *)timestamp;
 
 // TODO: error handling
 

--- a/Core/PARStore.m
+++ b/Core/PARStore.m
@@ -1350,7 +1350,13 @@ NSString *PARDevicesDirectoryName = @"devices";
         {
             [updatedDatabaseTimestamps setObject:logTimestamp forKey:store];
         }
-        
+
+        // we already have the latest value from that key
+        if (updatedValues[key] != nil)
+        {
+            continue;
+        }
+
         // blob --> object
         NSError *blobError = nil;
         NSData *blob = [log valueForKey:BlobAttributeName];

--- a/Tests/PARStoreTests.m
+++ b/Tests/PARStoreTests.m
@@ -166,7 +166,7 @@
     // second load = load document and compare data
     PARStoreExample *document2 = [PARStoreExample storeWithURL:url deviceIdentifier:[self deviceIdentifierForTest]];
     [document2 loadNow];
-    NSDictionary *actualEntries = document2.allRelevantValues;
+    NSDictionary *actualEntries = document2.allEntries;
     NSString *actualTitle = actualEntries[@"title"];
     NSString *actualFirst = actualEntries[@"first"];
     XCTAssertEqualObjects(actualTitle, title, @"unexpected 'title' value after closing and reopening a document: '%@' instead of '%@'", actualTitle, title);
@@ -195,7 +195,7 @@
     
     // get properties and compare data
     [document1 loadNow];
-    NSDictionary *actualEntries1 = document1.allRelevantValues;
+    NSDictionary *actualEntries1 = document1.allEntries;
     NSString *actualTitle = actualEntries1[@"title"];
     NSString *actualFirst = actualEntries1[@"first"];
     XCTAssertEqualObjects(actualTitle, title, @"unexpected 'title' value after closing database of document: '%@' instead of '%@'", actualTitle, title);
@@ -209,7 +209,7 @@
     // second load = load document and compare data
     PARStoreExample *document2 = [PARStoreExample storeWithURL:url deviceIdentifier:[self deviceIdentifierForTest]];
     [document2 loadNow];
-    NSDictionary *actualEntries2 = document2.allRelevantValues;
+    NSDictionary *actualEntries2 = document2.allEntries;
     NSString *actualSummary = actualEntries2[@"summary"];
     NSString *actualLast = actualEntries2[@"last"];
     XCTAssertEqualObjects(actualSummary, summary, @"unexpected 'summary' value after closing database, tearing down and reopening a document: '%@' instead of '%@'", actualSummary, summary);
@@ -611,7 +611,7 @@
     NSNumber *endTimestamp = [PARStore timestampNow];
     
     // actual changes
-    NSArray *changes = [storeExample changesSinceTimestamp:nil];
+    NSArray *changes = [storeExample fetchChangesSinceTimestamp:nil];
     
     // change count
     XCTAssertTrue(changes.count == 3, @"expected 3 changes but got %@", @(changes.count));
@@ -669,8 +669,8 @@
     [store2 syncNow];
     
     // actual changes
-    NSArray *changes1 = [store1 changesSinceTimestamp:nil];
-    NSArray *changes2 = [store2 changesSinceTimestamp:nil];
+    NSArray *changes1 = [store1 fetchChangesSinceTimestamp:nil];
+    NSArray *changes2 = [store2 fetchChangesSinceTimestamp:nil];
     XCTAssertEqualObjects(changes1, changes2, @"changes should be consistent in store1 and store2 because they come from the same URL");
     
     // change count


### PR DESCRIPTION
This change removes the need to specify `relevantKeysForSync` in subclasses.

Also tweaking a few method names to clarify their intent, in particular using the `fetch` prefix when database access is needed.
