### PR TITLE
Fix timestamp order from fetch request of logs

### DIFF
--- a/Core/PARStore.m
+++ b/Core/PARStore.m
@@ -1520,6 +1520,7 @@ NSString *PARBlobsDirectoryName = @"Blobs";
         // we may already have the latest value from that key
         if (updatedValues[key] != nil)
         {
+            // despite the sort descriptor set on the fetch request, the timestamp reverse order is not always respected; we thus have to check that if the timestamp is maybe later than the value already recorded for that key
             NSNumber *earliestTimestamp = updatedKeyTimestamps[key];
             if ([logTimestamp compare:earliestTimestamp] == NSOrderedAscending)
             {

--- a/Core/PARStore.m
+++ b/Core/PARStore.m
@@ -1517,12 +1517,16 @@ NSString *PARBlobsDirectoryName = @"Blobs";
             [updatedDatabaseTimestamps setObject:logTimestamp forKey:store];
         }
 
-        // we already have the latest value from that key
+        // we may already have the latest value from that key
         if (updatedValues[key] != nil)
         {
-            // Turn object back into fault to free up memory
-            [moc refreshObject:log mergeChanges:YES];
-            continue;
+            NSNumber *earliestTimestamp = updatedKeyTimestamps[key];
+            if ([logTimestamp compare:earliestTimestamp] == NSOrderedAscending)
+            {
+                // Turn object back into fault to free up memory
+                [moc refreshObject:log mergeChanges:YES];
+                continue;
+            }
         }
 
         // blob --> object


### PR DESCRIPTION
It looks like the sort descriptors are pretty much ignored when a fetch request is configured to return just the object IDs. This means the rows are not returned in the expected reverse timestamp order. The
issue seems close to 100% reproducible in 2 new tests just added. It’s not entirely clear if it’s 100% reproducible, as it will likely depends onthe timing and the order in which things are stored in the various database files.

In the end, the fix is very simple (the diff is remarkably small).

There also remains the question as to whether we should revert back to fetching the managed object themselves (for which I don't see the issue), see commit https://github.com/cparnot/PARStore/commit/9b0914f313c583035a5dca1b33a61 to be discussed with @drewmccormack : which approach is best, cons and pros, performance issues, etc. The workaround adds very little overhead, so I suspect we just keep things as-is, but still curious to hear your thoughts, Drew.