### PR TITLE
WIP: Enhanced Deletion

### DIFF
--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -68,12 +68,15 @@ extern NSString *PARStoreDidSyncNotification;
 - (BOOL)writeBlobFromPath:(NSString *)sourcePath toPath:(NSString *)path error:(NSError **)error;
 - (nullable NSData *)blobDataAtPath:(NSString *)path error:(NSError **)error;
 - (BOOL)deleteBlobAtPath:(NSString *)path error:(NSError **)error;
-- (BOOL)deleteBlobAtPath:(NSString *)path registeringDeletion: (BOOL)usingTombstone error:(NSError **)error;
 - (nullable NSString *)absolutePathForBlobPath:(NSString *)path;
 - (NSArray<NSString *> *)absolutePathsForBlobsPrefixedBy:(NSString *)prefix NS_SWIFT_NAME(absolutePaths(forBlobsPrefixedBy:));
 - (void)enumerateBlobs:(void(^)(NSString *path))block;
 - (BOOL)blobExistsAtPath:(NSString *)path;
+
+/// @name Registered Deletion Support
+- (BOOL)deleteBlobAtPath:(NSString *)path registeringDeletion: (BOOL)usingTombstone error:(NSError **)error;
 - (BOOL)blobIsRegisteredDeletedAtPath:(NSString *)path;
+- (void)enumerateDeletedBlobs:(void(^)(NSString *path))block;
 
 /// @name Syncing
 - (void)sync;

--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -74,7 +74,7 @@ extern NSString *PARStoreDidSyncNotification;
 - (BOOL)blobExistsAtPath:(NSString *)path;
 
 /// @name Registered Deletion Support
-- (BOOL)deleteBlobAtPath:(NSString *)path registeringDeletion: (BOOL)registeringDeletion error:(NSError **)error;
+- (BOOL)deleteBlobAtPath:(NSString *)path registeringDeletion: (BOOL)registeringDeletion ignoreIfMissing: (BOOL)ignoreIfMissing error:(NSError **)error;
 - (BOOL)blobIsRegisteredDeletedAtPath:(NSString *)path;
 - (void)enumerateDeletedBlobs:(void(^)(NSString *blobPath, NSString *markerPath))block;
 

--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -68,6 +68,7 @@ extern NSString *PARStoreDidSyncNotification;
 - (BOOL)writeBlobFromPath:(NSString *)sourcePath toPath:(NSString *)path error:(NSError **)error;
 - (nullable NSData *)blobDataAtPath:(NSString *)path error:(NSError **)error;
 - (BOOL)deleteBlobAtPath:(NSString *)path error:(NSError **)error;
+- (BOOL)deleteBlobAtPath:(NSString *)path usingTombstone: (BOOL)usingTombstone error:(NSError **)error;
 - (nullable NSString *)absolutePathForBlobPath:(NSString *)path;
 - (NSArray<NSString *> *)absolutePathsForBlobsPrefixedBy:(NSString *)prefix NS_SWIFT_NAME(absolutePaths(forBlobsPrefixedBy:));
 - (void)enumerateBlobs:(void(^)(NSString *path))block;

--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -76,7 +76,7 @@ extern NSString *PARStoreDidSyncNotification;
 /// @name Registered Deletion Support
 - (BOOL)deleteBlobAtPath:(NSString *)path registeringDeletion: (BOOL)usingTombstone error:(NSError **)error;
 - (BOOL)blobIsRegisteredDeletedAtPath:(NSString *)path;
-- (void)enumerateDeletedBlobs:(void(^)(NSString *path))block;
+- (void)enumerateDeletedBlobs:(void(^)(NSString *blobPath, NSString *markerPath))block;
 
 /// @name Syncing
 - (void)sync;

--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -74,7 +74,7 @@ extern NSString *PARStoreDidSyncNotification;
 - (BOOL)blobExistsAtPath:(NSString *)path;
 
 /// @name Registered Deletion Support
-- (BOOL)deleteBlobAtPath:(NSString *)path registeringDeletion: (BOOL)usingTombstone error:(NSError **)error;
+- (BOOL)deleteBlobAtPath:(NSString *)path registeringDeletion: (BOOL)registeringDeletion error:(NSError **)error;
 - (BOOL)blobIsRegisteredDeletedAtPath:(NSString *)path;
 - (void)enumerateDeletedBlobs:(void(^)(NSString *blobPath, NSString *markerPath))block;
 

--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -68,11 +68,12 @@ extern NSString *PARStoreDidSyncNotification;
 - (BOOL)writeBlobFromPath:(NSString *)sourcePath toPath:(NSString *)path error:(NSError **)error;
 - (nullable NSData *)blobDataAtPath:(NSString *)path error:(NSError **)error;
 - (BOOL)deleteBlobAtPath:(NSString *)path error:(NSError **)error;
-- (BOOL)deleteBlobAtPath:(NSString *)path usingTombstone: (BOOL)usingTombstone error:(NSError **)error;
+- (BOOL)deleteBlobAtPath:(NSString *)path registeringDeletion: (BOOL)usingTombstone error:(NSError **)error;
 - (nullable NSString *)absolutePathForBlobPath:(NSString *)path;
 - (NSArray<NSString *> *)absolutePathsForBlobsPrefixedBy:(NSString *)prefix NS_SWIFT_NAME(absolutePaths(forBlobsPrefixedBy:));
 - (void)enumerateBlobs:(void(^)(NSString *path))block;
 - (BOOL)blobExistsAtPath:(NSString *)path;
+- (BOOL)blobIsRegisteredDeletedAtPath:(NSString *)path;
 
 /// @name Syncing
 - (void)sync;

--- a/Core/PARStore.h
+++ b/Core/PARStore.h
@@ -72,6 +72,7 @@ extern NSString *PARStoreDidSyncNotification;
 - (nullable NSString *)absolutePathForBlobPath:(NSString *)path;
 - (NSArray<NSString *> *)absolutePathsForBlobsPrefixedBy:(NSString *)prefix NS_SWIFT_NAME(absolutePaths(forBlobsPrefixedBy:));
 - (void)enumerateBlobs:(void(^)(NSString *path))block;
+- (BOOL)blobExistsAtPath:(NSString *)path;
 
 /// @name Syncing
 - (void)sync;

--- a/Core/PARStore.m
+++ b/Core/PARStore.m
@@ -1633,7 +1633,7 @@ NSString *PARBlobsDirectoryName = @"Blobs";
     }
 }
 
-- (void)enumerateDeletedBlobs:(void(^)(NSString *path))block
+- (void)enumerateDeletedBlobs:(void(^)(NSString *blobPath, NSString *markerPath))block
 {
     if (!self._inMemory)
     {
@@ -1657,8 +1657,13 @@ NSString *PARBlobsDirectoryName = @"Blobs";
             // uses a sym linked "private" folder, causing the path to be different to what comes
             // out for the blobDirectoryURL.
             NSString *absolutePath = [url URLByResolvingSymlinksInPath].path;
-            NSString *relativePath = [absolutePath substringFromIndex:prefixLength];
-            block(relativePath);
+            NSString *relativeTombstonePath = [absolutePath substringFromIndex:prefixLength];
+            NSString *relativePath = [relativeTombstonePath stringByDeletingPathExtension];
+            
+            // we pass back both the path to the datafile and the path to the tombstone file
+            // since the relationship between the two is an implementation detail
+            // (right now it's just an extra file extension, but that may not always be true)
+            block(relativePath, relativeTombstonePath);
         }
     }
 }

--- a/Core/PARStore.m
+++ b/Core/PARStore.m
@@ -1391,7 +1391,8 @@ NSString *PARBlobsDirectoryName = @"Blobs";
 
 - (BOOL)writeTombstoneAtPath:(NSString *)tombstonePath forFileAtPath:(NSString *)filePath error:(NSError **)error
 {
-    if ([[NSFileManager defaultManager] fileExistsAtPath:tombstonePath]) {
+    if ([[NSFileManager defaultManager] fileExistsAtPath:tombstonePath])
+    {
         // if a tombstone already exists, we need not make it again
         return YES;
     }
@@ -1400,6 +1401,21 @@ NSString *PARBlobsDirectoryName = @"Blobs";
     NSDictionary* attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:error];
     NSDictionary* properties = @{ @"modified": attributes.fileModificationDate, @"size": @(attributes.fileSize), @"deleted": [NSDate date] };
     return [properties writeToFile:tombstonePath atomically:YES];
+}
+
+
+- (BOOL)blobExistsAtPath:(NSString *)path
+{
+    NSURL *blobURL = [[self blobDirectoryURL] URLByAppendingPathComponent:path];
+
+    // if a tombstone file exists, return NO, regardless of the presence of the actual file
+    NSURL* tombstoneURL = [blobURL URLByAppendingPathExtension:TombstoneFileExtension];
+    if ([[NSFileManager defaultManager] fileExistsAtPath:tombstoneURL.path])
+    {
+        return NO;
+    }
+    
+    return [[NSFileManager defaultManager] fileExistsAtPath:blobURL.path];
 }
 
 - (BOOL)deleteBlobAtPath:(NSString *)path usingTombstone: (BOOL)usingTombstone error:(NSError **)error

--- a/Core/PARStore.m
+++ b/Core/PARStore.m
@@ -1571,7 +1571,7 @@ NSString *PARBlobsDirectoryName = @"Blobs";
         for (NSURL *url in urls) {
             // the presence of a tombstone file will suppress enumeration of the
             // corresponding data file if it still exists
-            // (this shouldn't happen, but might do if file-syncing messes things up)
+            // (this shouldn't happen, but might do if external file-syncing messes things up)
             if (![tombstones containsObject:url]) {
                 // Resolving symbolic link here, because on iOS at least, the directory enumerator
                 // uses a sym linked "private" folder, causing the path to be different to what comes

--- a/Core/PARStore.m
+++ b/Core/PARStore.m
@@ -30,6 +30,8 @@ NSString *const KeyAttributeName             = @"key";
 NSString *const TimestampAttributeName       = @"timestamp";
 NSString *const ParentTimestampAttributeName = @"parentTimestamp";
 
+// tombstone constants
+NSString *const TombstoneFileExtension       = @"deleted";
 
 // A subclass of NSFileCoordinator that doesn't use coordination.
 // This is used to disable coordination, for a performance boost when it is not needed.
@@ -1387,6 +1389,11 @@ NSString *PARBlobsDirectoryName = @"Blobs";
     return [self deleteBlobAtPath:path usingTombstone: NO error:error];
 }
 
+- (NSString *)tombstonePathForBlobAtPath:(NSString *)path
+{
+    return [path stringByAppendingPathExtension: TombstoneFileExtension];
+}
+
 - (BOOL)writeTombstoneAtPath:(NSString *)tombstonePath forFileAtPath:(NSString *)filePath error:(NSError **)error
 {
     if ([[NSFileManager defaultManager] fileExistsAtPath:tombstonePath]) {
@@ -1425,7 +1432,7 @@ NSString *PARBlobsDirectoryName = @"Blobs";
     // otherwise blobs are stored in a special blob directory
     __block NSError *localError = nil;
     NSURL *fileURL = [[self blobDirectoryURL] URLByAppendingPathComponent:path];
-    NSURL *tombstoneURL = [fileURL URLByAppendingPathExtension:@"deleted"];
+    NSURL *tombstoneURL = [fileURL URLByAppendingPathExtension:TombstoneFileExtension];
 
     NSError *coordinatorError = nil;
     

--- a/Core/PARStore.m
+++ b/Core/PARStore.m
@@ -1389,7 +1389,15 @@ NSString *PARBlobsDirectoryName = @"Blobs";
 
 - (BOOL)writeTombstoneAtPath:(NSString *)tombstonePath forFileAtPath:(NSString *)filePath error:(NSError **)error
 {
-    return YES;
+    if ([[NSFileManager defaultManager] fileExistsAtPath:tombstonePath]) {
+        // if a tombstone already exists, we need not make it again
+        return YES;
+    }
+    
+    // the tombstone contains the original modification date and file size, along with the current time
+    NSDictionary* attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:error];
+    NSDictionary* properties = @{ @"modified": attributes.fileModificationDate, @"size": @(attributes.fileSize), @"deleted": [NSDate date] };
+    return [properties writeToFile:tombstonePath atomically:YES];
 }
 
 - (BOOL)deleteBlobAtPath:(NSString *)path usingTombstone: (BOOL)usingTombstone error:(NSError **)error

--- a/Core/PARStore.m
+++ b/Core/PARStore.m
@@ -1425,7 +1425,7 @@ NSString *PARBlobsDirectoryName = @"Blobs";
     return [self deleteBlobAtPath:path registeringDeletion: NO error:error];
 }
 
-- (BOOL)deleteBlobAtPath:(NSString *)path registeringDeletion: (BOOL)usingTombstone error:(NSError **)error
+- (BOOL)deleteBlobAtPath:(NSString *)path registeringDeletion: (BOOL)registeringDeletion error:(NSError **)error
 {
     // nil path = error
     if (path == nil)
@@ -1459,7 +1459,7 @@ NSString *PARBlobsDirectoryName = @"Blobs";
         NSError *error = nil;
         BOOL success = YES;
         
-        if (usingTombstone) {
+        if (registeringDeletion) {
             // write tombstone
             success = [self writeTombstoneAtPath:newTombstoneURL.path forFileAtPath:newURL.path error:&error];
             if (!success)

--- a/Core/PARStore.m
+++ b/Core/PARStore.m
@@ -1603,7 +1603,7 @@ NSString *PARBlobsDirectoryName = @"Blobs";
             NSFileManager *fileManager = [[NSFileManager alloc] init];
             for(NSURL* url in enumerator) {
                 BOOL isDir = false;
-                if ([fileManager fileExistsAtPath:url.path isDirectory:&isDir] && !isDir) continue;
+                if ([fileManager fileExistsAtPath:url.path isDirectory:&isDir] && isDir) continue;
                 if ([url.pathExtension isEqualToString: TombstoneFileExtension]) {
                     [tombstones addObject:[url URLByDeletingPathExtension]];
                 } else {

--- a/Core/PARStore.m
+++ b/Core/PARStore.m
@@ -1449,10 +1449,13 @@ NSString *PARBlobsDirectoryName = @"Blobs";
     
     [[self newFileCoordinator] coordinateWritingItemAtURL:fileURL options:NSFileCoordinatorWritingForReplacing writingItemAtURL:tombstoneURL options:NSFileCoordinatorWritingForReplacing error:&coordinatorError byAccessor:^(NSURL * _Nonnull newURL, NSURL * _Nonnull newTombstoneURL)
      {
-        // TODO: Decide how to interpret an existing tombstone file.
-        // The previous behaviour produced an error if the file had already been deleted.
-        // We could do this with the tombstone deletion too, or we could treat the presence of the
-        // tombstone as a sign that the file was deleted already and just quietly return success.
+        // TODO: Decide how to interpret a tombstone file being present already.
+        // With the previous implementation, I think that calling delete on a file that didn't exist
+        // (or had already been deleted) returned an error.
+        // To be consistent with this behaviour, we should perhaps also return an error if we
+        // find an existing tombstone file.
+        // However, my normal inclination would be to treat the presence of the tombstone as a sign
+        // that the file has been successfully deleted and quietly return success.
         
         NSError *error = nil;
 

--- a/Core/PARStore.m
+++ b/Core/PARStore.m
@@ -1449,7 +1449,7 @@ NSString *PARBlobsDirectoryName = @"Blobs";
     
     [[self newFileCoordinator] coordinateWritingItemAtURL:fileURL options:NSFileCoordinatorWritingForReplacing writingItemAtURL:tombstoneURL options:NSFileCoordinatorWritingForReplacing error:&coordinatorError byAccessor:^(NSURL * _Nonnull newURL, NSURL * _Nonnull newTombstoneURL)
      {
-        // TODO: Decide how to interpret existing tombstone file.
+        // TODO: Decide how to interpret an existing tombstone file.
         // The previous behaviour produced an error if the file had already been deleted.
         // We could do this with the tombstone deletion too, or we could treat the presence of the
         // tombstone as a sign that the file was deleted already and just quietly return success.
@@ -1519,6 +1519,9 @@ NSString *PARBlobsDirectoryName = @"Blobs";
         ErrorLog(@"%@", description);
         if (error != NULL)
             *error = [NSError errorWithObject:self code:__LINE__ localizedDescription:description underlyingError:nil];
+        
+        // TODO: should we attempt to clean up sync errors here, by deleting the data file if it still exists?
+        
         return nil;
     }
     
@@ -1604,7 +1607,11 @@ NSString *PARBlobsDirectoryName = @"Blobs";
                 NSString *absolutePath = [url URLByResolvingSymlinksInPath].path;
                 NSString *relativePath = [absolutePath substringFromIndex:prefixLength];
                 block(relativePath);
-            }
+            } /* else {
+               // TODO: if thshould we attempt to clean up sync errors here, by deleting the data file if it still exists?
+            }*/
+            
+
         }
     }
 }

--- a/PARStore.xcodeproj/project.pbxproj
+++ b/PARStore.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		56EAE1BB16E24E7300A7F31F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 56EAE1B816E24E7300A7F31F /* main.m */; };
 		56EAE1BE16E24EAA00A7F31F /* PARStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 56EAE1BD16E24EAA00A7F31F /* PARStore.m */; };
 		56FA3D771970359C00BF81D3 /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 56FA3D761970359C00BF81D3 /* libsqlite3.dylib */; };
+		8BED6AEB26824978004639DF /* PARStoreBlobTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BED6AEA26824978004639DF /* PARStoreBlobTests.m */; };
+		8BED6AEC26824978004639DF /* PARStoreBlobTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BED6AEA26824978004639DF /* PARStoreBlobTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -114,6 +116,7 @@
 		56EAE1BC16E24EAA00A7F31F /* PARStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PARStore.h; path = Core/PARStore.h; sourceTree = SOURCE_ROOT; };
 		56EAE1BD16E24EAA00A7F31F /* PARStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = PARStore.m; path = Core/PARStore.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		56FA3D761970359C00BF81D3 /* libsqlite3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsqlite3.dylib; path = usr/lib/libsqlite3.dylib; sourceTree = SDKROOT; };
+		8BED6AEA26824978004639DF /* PARStoreBlobTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PARStoreBlobTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -265,6 +268,7 @@
 				56C7EDFA16E26D0700FFBBF2 /* PARTestCase.h */,
 				56C7EDFB16E26D0700FFBBF2 /* PARTestCase.m */,
 				56EAE19416E24C7500A7F31F /* PARStoreTests.m */,
+				8BED6AEA26824978004639DF /* PARStoreBlobTests.m */,
 				561148E6196E952800F488F2 /* PARSQLiteTests.m */,
 				56E196E41B448BE600A51AB0 /* PARDispatchQueueTests.m */,
 				56EAE18E16E24C7500A7F31F /* Supporting Files */,
@@ -456,6 +460,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8BED6AEC26824978004639DF /* PARStoreBlobTests.m in Sources */,
 				56C7EDF716E2687F00FFBBF2 /* PARStoreTests.m in Sources */,
 				56C7EDFD16E26D0700FFBBF2 /* PARTestCase.m in Sources */,
 			);
@@ -480,6 +485,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				56EAE19516E24C7500A7F31F /* PARStoreTests.m in Sources */,
+				8BED6AEB26824978004639DF /* PARStoreBlobTests.m in Sources */,
 				56E196E61B448CA300A51AB0 /* PARDispatchQueueTests.m in Sources */,
 				56C7EDFC16E26D0700FFBBF2 /* PARTestCase.m in Sources */,
 				561148E7196E952800F488F2 /* PARSQLiteTests.m in Sources */,

--- a/Tests/PARStoreBlobTests.m
+++ b/Tests/PARStoreBlobTests.m
@@ -38,6 +38,8 @@ extern NSString *const TombstoneFileExtension; // normally private, but exposed 
 
 - (void)testDeletion
 {
+    // deleting a blob with the old API should work as before
+    
     NSError *error = nil;
     NSURL *url = [[self urlWithUniqueTmpDirectory] URLByAppendingPathComponent:@"doc.parstore"];
     PARStore *store = [PARStore storeWithURL:url deviceIdentifier:[self deviceIdentifierForTest]];
@@ -61,6 +63,7 @@ extern NSString *const TombstoneFileExtension; // normally private, but exposed 
 
 - (void)testDeletionWithTombstone
 {
+    // deleting a blob with the new API should result in a tombstone file
     NSError *error = nil;
     NSURL *url = [[self urlWithUniqueTmpDirectory] URLByAppendingPathComponent:@"doc.parstore"];
     PARStore *store = [PARStore storeWithURL:url deviceIdentifier:[self deviceIdentifierForTest]];
@@ -85,6 +88,8 @@ extern NSString *const TombstoneFileExtension; // normally private, but exposed 
 
 - (void)testBlobExists
 {
+    // exists should product the right result before/after creation of a blob file
+    
     NSError *error = nil;
     NSURL *url = [[self urlWithUniqueTmpDirectory] URLByAppendingPathComponent:@"doc.parstore"];
     PARStore *store = [PARStore storeWithURL:url deviceIdentifier:[self deviceIdentifierForTest]];
@@ -99,6 +104,9 @@ extern NSString *const TombstoneFileExtension; // normally private, but exposed 
 
 - (void)testTombstoneSuppressesFileExistence
 {
+    // if there's a tombstone file present, exists should return NO even if the actual blob
+    // file is still present
+    
     NSError *error = nil;
     NSURL *url = [[self urlWithUniqueTmpDirectory] URLByAppendingPathComponent:@"doc.parstore"];
     PARStore *store = [PARStore storeWithURL:url deviceIdentifier:[self deviceIdentifierForTest]];
@@ -117,6 +125,9 @@ extern NSString *const TombstoneFileExtension; // normally private, but exposed 
 
 - (void)testTombstoneSuppressesData
 {
+    // if there is a tombstone file present, no data should be returned even if the actual blob
+    // file is still present
+    
     NSError *error = nil;
     NSURL *url = [[self urlWithUniqueTmpDirectory] URLByAppendingPathComponent:@"doc.parstore"];
     PARStore *store = [PARStore storeWithURL:url deviceIdentifier:[self deviceIdentifierForTest]];
@@ -134,6 +145,9 @@ extern NSString *const TombstoneFileExtension; // normally private, but exposed 
 
 - (void)testTombstoneSuppressesEnumeration
 {
+    // tombstone files shoulnd't be included in the enumeration
+    // the presence of a tombstone file should also cause the corresponding data file to be skipped
+    // from the enumeration (if it still exists)
     NSError *error = nil;
     NSURL *url = [[self urlWithUniqueTmpDirectory] URLByAppendingPathComponent:@"doc.parstore"];
     PARStore *store = [PARStore storeWithURL:url deviceIdentifier:[self deviceIdentifierForTest]];

--- a/Tests/PARStoreBlobTests.m
+++ b/Tests/PARStoreBlobTests.m
@@ -148,7 +148,7 @@ extern NSString *const TombstoneFileExtension; // normally private, but exposed 
 
 - (void)testTombstoneSuppressesEnumeration
 {
-    // tombstone files shoulnd't be included in the enumeration
+    // tombstone files shouldn't be included in the enumeration
     // the presence of a tombstone file should also cause the corresponding data file to be skipped
     // from the enumeration (if it still exists)
     NSError *error = nil;
@@ -174,6 +174,7 @@ extern NSString *const TombstoneFileExtension; // normally private, but exposed 
 
 - (void)testEnumeratingTombstones
 {
+    // we should be called back with both the original data file paths, and the paths to the tombstones
     NSError *error = nil;
     NSURL *url = [[self urlWithUniqueTmpDirectory] URLByAppendingPathComponent:@"doc.parstore"];
     PARStore *store = [PARStore storeWithURL:url deviceIdentifier:[self deviceIdentifierForTest]];
@@ -185,10 +186,12 @@ extern NSString *const TombstoneFileExtension; // normally private, but exposed 
     XCTAssertTrue([store deleteBlobAtPath:@"blob3" registeringDeletion: YES error:&error]);
 
     __block int count = 0;
-    NSArray* expected = @[@"blob1.deleted", @"blob3.deleted"];
-    [store enumerateDeletedBlobs:^(NSString *blobPath) {
+    NSArray* expected = @[@"blob1", @"blob3"];
+    NSArray* expectedTombstones = @[@"blob1.deleted", @"blob3.deleted"];
+    [store enumerateDeletedBlobs:^(NSString *blobPath, NSString *markerPath) {
         ++count;
         XCTAssertTrue([expected containsObject: blobPath]);
+        XCTAssertTrue([expectedTombstones containsObject: markerPath]);
     }];
     XCTAssertEqual(count, 2);
     

--- a/Tests/PARStoreBlobTests.m
+++ b/Tests/PARStoreBlobTests.m
@@ -40,7 +40,15 @@
     NSURL *url = [[self urlWithUniqueTmpDirectory] URLByAppendingPathComponent:@"doc.parstore"];
     PARStore *store = [PARStore storeWithURL:url deviceIdentifier:[self deviceIdentifierForTest]];
     XCTAssertTrue([store writeBlobData:[@"test" dataUsingEncoding:NSUTF8StringEncoding] toPath:@"blob" error:&error]);
+
+    NSURL *blobURL = [[url URLByAppendingPathComponent: @"Blobs"] URLByAppendingPathComponent: @"blob"];
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath: blobURL.path]);
+
     XCTAssertTrue([store deleteBlobAtPath:@"blob" error:&error]);
+
+    // blob file should have gone
+    XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath: blobURL.path]);
+
     [store tearDownNow];
 }
 
@@ -50,7 +58,19 @@
     NSURL *url = [[self urlWithUniqueTmpDirectory] URLByAppendingPathComponent:@"doc.parstore"];
     PARStore *store = [PARStore storeWithURL:url deviceIdentifier:[self deviceIdentifierForTest]];
     XCTAssertTrue([store writeBlobData:[@"test" dataUsingEncoding:NSUTF8StringEncoding] toPath:@"blob" error:&error]);
+
+    NSURL *blobURL = [[url URLByAppendingPathComponent: @"Blobs"] URLByAppendingPathComponent: @"blob"];
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath: blobURL.path]);
+
     XCTAssertTrue([store deleteBlobAtPath:@"blob" usingTombstone: YES error:&error]);
+
+    // blob file should have gone
+    XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath: blobURL.path]);
+    
+    // tombstone file should have appeared in its place
+    NSURL *tombstoneURL = [blobURL URLByAppendingPathExtension: @"deleted"];
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath: tombstoneURL.path]);
+
     [store tearDownNow];
 }
 

--- a/Tests/PARStoreBlobTests.m
+++ b/Tests/PARStoreBlobTests.m
@@ -52,6 +52,10 @@ extern NSString *const TombstoneFileExtension; // normally private, but exposed 
     // blob file should have gone
     XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath: blobPath]);
 
+    // tombstone file should not have appeared in its place
+    NSString *tombstonePath = [blobPath stringByAppendingPathExtension: TombstoneFileExtension];
+    XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath: tombstonePath]);
+
     [store tearDownNow];
 }
 

--- a/Tests/PARStoreBlobTests.m
+++ b/Tests/PARStoreBlobTests.m
@@ -1,0 +1,57 @@
+//  PARStoreBlobTests
+//  Created by Sam Deane on 22/06/21.
+//  All code (c) 2021 - present day, Elegant Chaos Limited.
+
+#import "PARTestCase.h"
+#import "PARStoreExample.h"
+#import "PARNotificationSemaphore.h"
+
+@interface PARStoreBlobTests : PARTestCase
+
+@end
+
+
+@implementation PARStoreBlobTests
+
+- (void)setUp
+{
+    [super setUp];
+    
+    // Set-up code here.
+}
+
+- (void)tearDown
+{
+    // Tear-down code here.
+    
+    [super tearDown];
+}
+
+- (NSString *)deviceIdentifierForTest
+{
+    return @"948E9EEE-3398-4DD7-9183-C56866EF2350";
+}
+
+#pragma mark - 
+
+- (void)testDeletion
+{
+    NSError *error = nil;
+    NSURL *url = [[self urlWithUniqueTmpDirectory] URLByAppendingPathComponent:@"doc.parstore"];
+    PARStore *store = [PARStore storeWithURL:url deviceIdentifier:[self deviceIdentifierForTest]];
+    XCTAssertTrue([store writeBlobData:[@"test" dataUsingEncoding:NSUTF8StringEncoding] toPath:@"blob" error:&error]);
+    XCTAssertTrue([store deleteBlobAtPath:@"blob" error:&error]);
+    [store tearDownNow];
+}
+
+- (void)testDeletionWithTombstone
+{
+    NSError *error = nil;
+    NSURL *url = [[self urlWithUniqueTmpDirectory] URLByAppendingPathComponent:@"doc.parstore"];
+    PARStore *store = [PARStore storeWithURL:url deviceIdentifier:[self deviceIdentifierForTest]];
+    XCTAssertTrue([store writeBlobData:[@"test" dataUsingEncoding:NSUTF8StringEncoding] toPath:@"blob" error:&error]);
+    XCTAssertTrue([store deleteBlobAtPath:@"blob" usingTombstone: YES error:&error]);
+    [store tearDownNow];
+}
+
+@end

--- a/Tests/PARStoreBlobTests.m
+++ b/Tests/PARStoreBlobTests.m
@@ -76,7 +76,7 @@ extern NSString *const TombstoneFileExtension; // normally private, but exposed 
     [store tearDownNow];
 }
 
-- (void)testTombstonePreventsData
+- (void)testTombstoneSuppressesData
 {
     NSError *error = nil;
     NSURL *url = [[self urlWithUniqueTmpDirectory] URLByAppendingPathComponent:@"doc.parstore"];
@@ -93,7 +93,7 @@ extern NSString *const TombstoneFileExtension; // normally private, but exposed 
     [store tearDownNow];
 }
 
-- (void)testTombstonePreventsEnumeration
+- (void)testTombstoneSuppressesEnumeration
 {
     NSError *error = nil;
     NSURL *url = [[self urlWithUniqueTmpDirectory] URLByAppendingPathComponent:@"doc.parstore"];

--- a/Tests/PARStoreBlobTests.m
+++ b/Tests/PARStoreBlobTests.m
@@ -72,7 +72,7 @@ extern NSString *const TombstoneFileExtension; // normally private, but exposed 
     NSString *blobPath = [store absolutePathForBlobPath: @"blob"];
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath: blobPath]);
 
-    XCTAssertTrue([store deleteBlobAtPath:@"blob" usingTombstone: YES error:&error]);
+    XCTAssertTrue([store deleteBlobAtPath:@"blob" registeringDeletion: YES error:&error]);
     XCTAssertFalse([store blobExistsAtPath:@"blob"]);
 
     // blob file should have gone


### PR DESCRIPTION
Work in progress on some changes for use in Agenda.

Adds the facility to replace deleted blob files with a "tombstone" marker file which forces the rest of the API to treat the blob as deleted even if the actual data file returns.

This is intended to work around situations where the blob directory is being synced with an external service that might get confused and put back deleted files instead of removing them.

*Note*: the behaviour of the existing `deleteBlobAtPath` call should be unaffected by these changes. A new variant of the call has been added to opt-in to tombstones. Other API has been updated to be aware of the presence of tombstone files, but should be unaffected if they are never created. There will be a minor reduction in efficiency due to the need to check for tombstones, but it shouldn't be significant in comparison to whatever work is actually done with the files.